### PR TITLE
Add Google Gemini support

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 - Easy llm interface; eliminates parsing json responses or building up json for functions/tools
     - OpenAI and any OpenAI-compatible API
     - Anthropic
+    - Google Gemini
 - Sync and Async support
 - Functions/Tools
 - Structured Output
@@ -46,3 +47,51 @@ print(summary)
 ## Installation
 
 `uv install sik-llms` or `pip install sik-llms`
+
+### Authentication
+
+Set the relevant provider API keys in your environment before running examples or tests:
+
+- `OPENAI_API_KEY` for OpenAI-compatible providers
+- `ANTHROPIC_API_KEY` for Anthropic
+- `GOOGLE_API_KEY` (or `GEMINI_API_KEY`) for Google Gemini
+
+#### Getting a Google Gemini API key with `gcloud`
+
+1. Make sure the Generative Language API is enabled for your project:
+
+   ```bash
+   gcloud services enable generativelanguage.googleapis.com --project YOUR_PROJECT_ID
+   ```
+
+2. Create or reuse an API key:
+
+   ```bash
+   gcloud services api-keys create \
+     --project YOUR_PROJECT_ID \
+     --display-name "sik-llms-gemini"
+   ```
+
+   To list existing keys:
+
+   ```bash
+   gcloud services api-keys list --project YOUR_PROJECT_ID
+   ```
+
+3. Fetch the key string and export it for the SDK:
+
+   ```bash
+   export GOOGLE_API_KEY=$(gcloud services api-keys get-key-string KEY_ID --project YOUR_PROJECT_ID)
+   ```
+
+   Replace `KEY_ID` with the identifier returned by `list` or `create`.
+
+#### Minimal Gemini usage
+
+```python
+from sik_llms import create_client, user_message
+
+client = create_client(model_name="gemini-2.5-flash")
+response = client(messages=[user_message("Summarize the latest updates to the Gemini family.")])
+print(response.response)
+```

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,6 +9,7 @@ dependencies = [
     "mcp[cli]>=1.12.4",
     "nest-asyncio>=1.6.0",
     "openai>=1.99.6",
+    "google-genai>=1.41.0",
     "pydantic>=2.11.7",
     "python-dotenv>=1.1.1",
     "tiktoken>=0.11.0",

--- a/src/sik_llms/__init__.py
+++ b/src/sik_llms/__init__.py
@@ -37,11 +37,17 @@ from sik_llms.anthropic import (
     AnthropicTools,
     SUPPORTED_ANTHROPIC_MODELS,
 )
+from sik_llms.gemini import (
+    Gemini,
+    GeminiTools,
+    SUPPORTED_GEMINI_MODELS,
+)
 from sik_llms.reasoning_agent import ReasoningAgent
 
 SUPPORTED_MODELS: dict[str, ModelInfo] = {
     **SUPPORTED_OPENAI_MODELS,
     **SUPPORTED_ANTHROPIC_MODELS,
+    **SUPPORTED_GEMINI_MODELS,
 }
 
 def _get_client_type(model_name: str, client_type: str | Enum | None) -> str | Enum:
@@ -51,6 +57,8 @@ def _get_client_type(model_name: str, client_type: str | Enum | None) -> str | E
         return RegisteredClients.OPENAI
     if model_name in SUPPORTED_ANTHROPIC_MODELS:
         return RegisteredClients.ANTHROPIC
+    if model_name in SUPPORTED_GEMINI_MODELS:
+        return RegisteredClients.GEMINI
     raise ValueError(f"Unknown model name '{model_name}'")
 
 def create_client(
@@ -116,4 +124,6 @@ __all__ = [  # noqa: RUF022
     'OpenAITools',
     'Anthropic',
     'AnthropicTools',
+    'Gemini',
+    'GeminiTools',
 ]

--- a/src/sik_llms/gemini.py
+++ b/src/sik_llms/gemini.py
@@ -1,0 +1,588 @@
+"""Helper functions for interacting with the Google Gemini API."""
+
+from __future__ import annotations
+
+import asyncio
+import base64
+import json
+import os
+import threading
+from copy import deepcopy
+from datetime import date
+from time import perf_counter
+from collections.abc import AsyncGenerator
+from typing import Any
+
+from dotenv import load_dotenv
+from google import genai
+from google.genai import types
+from pydantic import BaseModel
+
+from sik_llms.models_base import (
+    Client,
+    ImageContent,
+    ImageSourceType,
+    ModelInfo,
+    ModelProvider,
+    RegisteredClients,
+    StructuredOutputResponse,
+    TextChunkEvent,
+    TextResponse,
+    Tool,
+    ToolChoice,
+    ToolPrediction,
+    ToolPredictionResponse,
+)
+from sik_llms.utilities import get_json_schema_type
+
+
+load_dotenv()
+
+
+# Pricing is stored per-token (per 1M tokens on the pricing page).
+GEMINI_MODEL_INFOS = [
+    ModelInfo(
+        model="gemini-2.5-pro",
+        provider=ModelProvider.GOOGLE,
+        max_output_tokens=65_536,
+        context_window_size=1_048_576,
+        pricing={
+            "input": 1.25 / 1_000_000,
+            "output": 10.00 / 1_000_000,
+            "input_long": 2.50 / 1_000_000,
+            "output_long": 15.00 / 1_000_000,
+            "cached": 0.31 / 1_000_000,
+        },
+        supports_reasoning=True,
+        supports_tools=True,
+        supports_structured_output=True,
+        supports_images=True,
+        knowledge_cutoff_date=date(year=2025, month=1, day=1),
+    ),
+    ModelInfo(
+        model="gemini-2.5-flash",
+        provider=ModelProvider.GOOGLE,
+        max_output_tokens=65_536,
+        context_window_size=1_048_576,
+        pricing={
+            "input": 0.30 / 1_000_000,
+            "output": 2.50 / 1_000_000,
+            "cached": 0.075 / 1_000_000,
+        },
+        supports_reasoning=True,
+        supports_tools=True,
+        supports_structured_output=True,
+        supports_images=True,
+        knowledge_cutoff_date=date(year=2025, month=1, day=1),
+    ),
+    ModelInfo(
+        model="gemini-2.5-flash-lite",
+        provider=ModelProvider.GOOGLE,
+        max_output_tokens=65_536,
+        context_window_size=1_048_576,
+        pricing={
+            "input": 0.10 / 1_000_000,
+            "output": 0.40 / 1_000_000,
+            "cached": 0.025 / 1_000_000,
+        },
+        supports_reasoning=True,
+        supports_tools=True,
+        supports_structured_output=True,
+        supports_images=True,
+        knowledge_cutoff_date=date(year=2025, month=1, day=1),
+    ),
+]
+
+
+SUPPORTED_GEMINI_MODELS = {model.model: model for model in GEMINI_MODEL_INFOS}
+
+
+def _ensure_api_key(api_key: str | None) -> str:
+    """Return a Gemini API key, preferring explicit input then environment variables."""
+    env_key = api_key or os.getenv("GOOGLE_API_KEY") or os.getenv("GEMINI_API_KEY")
+    if not env_key:
+        raise ValueError("GOOGLE_API_KEY or GEMINI_API_KEY environment variable must be set.")
+    return env_key
+
+
+def _convert_to_parts(content: str | list[str | ImageContent]) -> list[types.Part]:
+    """Convert internal message content into Gemini parts."""
+    parts: list[types.Part] = []
+    if isinstance(content, str):
+        stripped = content.strip()
+        if stripped:
+            parts.append(types.Part.from_text(text=stripped))
+        return parts or [types.Part.from_text(text="")]
+
+    if not isinstance(content, list):
+        raise TypeError(f"Unsupported message content type: {type(content)}")
+
+    for item in content:
+        if isinstance(item, str):
+            stripped = item.strip()
+            parts.append(types.Part.from_text(text=stripped))
+        elif isinstance(item, ImageContent):
+            if item.source_type == ImageSourceType.URL:
+                parts.append(
+                    types.Part.from_uri(
+                        uri=item.data,
+                        mime_type=item.media_type or "image/png",
+                    ),
+                )
+            elif item.source_type == ImageSourceType.BASE64:
+                binary = base64.b64decode(item.data)
+                parts.append(
+                    types.Part.from_bytes(
+                        data=binary,
+                        mime_type=item.media_type or "image/png",
+                    ),
+                )
+        else:
+            raise TypeError(f"Unsupported content item type: {type(item)}")
+
+    return parts or [types.Part.from_text(text="")]
+
+
+def _convert_messages(
+    messages: list[dict[str, Any]],
+    cache_content: list[str] | str | None,
+) -> tuple[str | None, list[types.Content]]:
+    """Convert internal messages into Gemini system instruction and content list."""
+    system_segments: list[str] = []
+    contents: list[types.Content] = []
+
+    if cache_content:
+        cached_list = [cache_content] if isinstance(cache_content, str) else list(cache_content)
+        for cached in cached_list:
+            contents.append(types.Content(role="user", parts=_convert_to_parts(cached)))
+
+    for message in messages:
+        role = message.get("role")
+        content = message.get("content", "")
+        if role == "system":
+            if isinstance(content, str):
+                system_segments.append(content.strip())
+            elif isinstance(content, list):
+                system_segments.extend(
+                    segment.strip() for segment in content if isinstance(segment, str)
+                )
+            else:
+                raise TypeError(f"Unsupported system content type: {type(content)}")
+            continue
+
+        if role not in {"user", "assistant", "model"}:
+            raise ValueError(f"Unsupported role `{role}` for Gemini messages.")
+
+        gemini_role = "user" if role == "user" else "model"
+        parts = _convert_to_parts(content)
+        contents.append(types.Content(role=gemini_role, parts=parts))
+
+    system_instruction = "\n\n".join(segment for segment in system_segments if segment) or None
+    return system_instruction, contents
+
+
+def _create_generation_config(
+    model_parameters: dict[str, Any],
+    response_format: type[BaseModel] | None,
+) -> types.GenerateContentConfig | None:
+    """Create the Gemini generation config for the request."""
+    if not model_parameters and not response_format:
+        return None
+
+    config_kwargs = deepcopy(model_parameters) if model_parameters else {}
+    if response_format:
+        config_kwargs.setdefault("response_mime_type", "application/json")
+        config_kwargs["response_schema"] = response_format
+
+    return types.GenerateContentConfig(**config_kwargs)
+
+
+def _collect_usage_metadata(response) -> tuple[int, int, int | None]:  # noqa: ANN001
+    """Return token accounting from a Gemini response."""
+    usage = getattr(response, "usage_metadata", None)
+    if not usage:
+        return 0, 0, 0, None
+
+    input_tokens = getattr(usage, "prompt_token_count", 0) or 0
+    output_tokens = getattr(usage, "candidates_token_count", 0) or 0
+    thoughts_tokens = getattr(usage, "thoughts_token_count", 0) or 0
+    cached_tokens = getattr(usage, "cached_content_token_count", 0)
+    total_output_tokens = output_tokens + thoughts_tokens
+    return input_tokens, total_output_tokens, cached_tokens
+
+
+def _calculate_cost(
+    input_tokens: int,
+    output_tokens: int,
+    cached_tokens: int | None,
+    pricing_lookup: dict[str, float] | None,
+) -> tuple[float | None, float | None, float | None]:
+    """Calculate token-based costs using the model pricing metadata."""
+    if not pricing_lookup:
+        return None, None, None
+
+    input_cost = input_tokens * pricing_lookup.get("input", 0)
+    output_cost = output_tokens * pricing_lookup.get("output", 0)
+    cache_cost = None
+    if cached_tokens:
+        cache_rate = pricing_lookup.get("cached") or pricing_lookup.get("cache", 0)
+        cache_cost = cached_tokens * cache_rate if cache_rate else None
+    return input_cost, output_cost, cache_cost
+
+
+def _model_parameters_without_tools(model_parameters: dict[str, Any]) -> dict[str, Any]:
+    """Return model parameters without tool-specific keys."""
+    return {
+        key: value
+        for key, value in model_parameters.items()
+        if key not in {"tools", "tool_config"}
+    }
+
+
+def _tool_to_schema(tool: Tool) -> dict[str, Any]:
+    properties = {}
+    required: list[str] = []
+
+    for param in tool.parameters:
+        try:
+            json_type, extra = get_json_schema_type(param.param_type)
+        except ValueError:
+            json_type, extra = "string", {}
+
+        schema: dict[str, Any] = {"type": json_type, **extra}
+        if param.description:
+            schema["description"] = param.description
+        if param.valid_values:
+            schema["enum"] = param.valid_values
+        if param.any_of:
+            any_of = []
+            for union_type in param.any_of:
+                try:
+                    union_json_type, union_extra = get_json_schema_type(union_type)
+                except ValueError:
+                    union_json_type, union_extra = "string", {}
+                any_of.append({"type": union_json_type, **union_extra})
+            schema["anyOf"] = any_of
+        properties[param.name] = schema
+        if param.required:
+            required.append(param.name)
+
+    schema_dict: dict[str, Any] = {
+        "type": "object",
+        "properties": properties,
+        "additionalProperties": False,
+    }
+    if required:
+        schema_dict["required"] = required
+    return schema_dict
+
+
+def _tools_to_gemini_tools(
+    tools: list[Tool],
+) -> tuple[list[types.Tool], list[types.FunctionDeclaration]]:
+    declarations: list[types.FunctionDeclaration] = []
+    for tool in tools:
+        declarations.append(
+            types.FunctionDeclaration(
+                name=tool.name,
+                description=tool.description,
+                parameters=_tool_to_schema(tool),
+            ),
+        )
+    gemini_tool = types.Tool(function_declarations=declarations)
+    return [gemini_tool], declarations
+
+
+def _tool_response_to_prediction(response) -> tuple[ToolPrediction | None, str | None]:  # noqa: ANN001
+    """Extract tool prediction or assistant message from a Gemini response."""
+    candidates = getattr(response, "candidates", None) or []
+    if not candidates:
+        return None, None
+
+    candidate = candidates[0]
+    parts = getattr(candidate, "content", None)
+    if parts is None:
+        return None, None
+
+    for part in parts.parts:
+        function_call = getattr(part, "function_call", None)
+        if function_call:
+            arguments = function_call.args
+            if hasattr(arguments, "to_dict"):
+                arguments = arguments.to_dict()
+            elif hasattr(arguments, "items"):
+                arguments = dict(arguments)
+            if arguments is not None and not isinstance(arguments, dict | list):
+                arguments = json.loads(json.dumps(arguments))
+            return (
+                ToolPrediction(
+                    name=function_call.name,
+                    arguments=arguments or {},
+                    call_id=function_call.name,
+                ),
+                None,
+            )
+
+        text = getattr(part, "text", None)
+        if text:
+            return None, text
+
+    return None, None
+
+
+@Client.register(RegisteredClients.GEMINI)
+class Gemini(Client):
+    """Wrapper around the Gemini SDK for text and multimodal responses."""
+
+    def __init__(
+        self,
+        model_name: str,
+        response_format: type[BaseModel] | None = None,
+        cache_content: list[str] | str | None = None,
+        api_key: str | None = None,
+        client_kwargs: dict[str, Any] | None = None,
+        **model_kwargs: object,
+    ) -> None:
+        model_info = SUPPORTED_GEMINI_MODELS.get(model_name)
+        if not model_info:
+            raise ValueError(f"Model '{model_name}' is not supported for Gemini.")
+
+        api_key_value = _ensure_api_key(api_key)
+        client_kwargs = client_kwargs or {}
+        client_kwargs.setdefault("api_key", api_key_value)
+        self.client = genai.Client(**client_kwargs)
+        self.model = model_info.model
+        self.response_format = response_format
+        self.cache_content = cache_content
+        self.model_parameters = {
+            key: value for key, value in model_kwargs.items() if value is not None
+        }
+
+    async def stream(  # noqa: PLR0915
+        self,
+        messages: list[dict[str, Any]],
+    ) -> AsyncGenerator[TextChunkEvent | TextResponse | StructuredOutputResponse, None]:
+        """Stream Gemini responses, yielding text chunks and final summaries."""
+        model_info = SUPPORTED_GEMINI_MODELS.get(self.model)
+        pricing_lookup = model_info.pricing if model_info else None
+
+        system_instruction, contents = _convert_messages(messages, self.cache_content)
+        config = _create_generation_config(self.model_parameters, self.response_format)
+
+        request_kwargs = {
+            "model": self.model,
+            "contents": contents,
+        }
+        if system_instruction:
+            request_kwargs["system_instruction"] = system_instruction
+        if config:
+            request_kwargs["config"] = config
+
+        if self.response_format:
+            start_time = perf_counter()
+            response = await asyncio.to_thread(
+                self.client.models.generate_content,
+                **request_kwargs,
+            )
+            end_time = perf_counter()
+            input_tokens, output_tokens, cached_tokens = _collect_usage_metadata(response)
+            input_cost, output_cost, cache_cost = _calculate_cost(
+                input_tokens,
+                output_tokens,
+                cached_tokens,
+                pricing_lookup,
+            )
+
+            parsed = getattr(response, "parsed", None)
+            if parsed is None and response.candidates:
+                candidate = response.candidates[0]
+                parsed = next(
+                    (
+                        json.loads(part.text)
+                        for part in candidate.content.parts
+                        if getattr(part, "text", None)
+                    ),
+                    None,
+                )
+                if parsed and self.response_format:
+                    parsed = self.response_format.model_validate(parsed)
+
+            refusal = None
+            if (
+                response.candidates
+                and getattr(response.candidates[0], "finish_reason", None) == "SAFETY"
+            ):
+                refusal = "Response blocked for safety reasons."
+
+            yield StructuredOutputResponse(
+                parsed=parsed,
+                refusal=refusal,
+                input_tokens=input_tokens,
+                output_tokens=output_tokens,
+                cache_read_tokens=cached_tokens,
+                input_cost=input_cost,
+                output_cost=output_cost,
+                cache_read_cost=cache_cost,
+                duration_seconds=end_time - start_time,
+            )
+            return
+
+        loop = asyncio.get_running_loop()
+        queue: asyncio.Queue = asyncio.Queue()
+        final_future = loop.create_future()
+
+        def worker() -> None:
+            try:
+                stream = self.client.models.generate_content_stream(**request_kwargs)
+                for chunk in stream:
+                    loop.call_soon_threadsafe(queue.put_nowait, chunk)
+                final_response = stream.get_final_response()
+                if not final_future.done():
+                    loop.call_soon_threadsafe(final_future.set_result, final_response)
+            except Exception as exc:
+                if not final_future.done():
+                    loop.call_soon_threadsafe(final_future.set_exception, exc)
+            finally:
+                loop.call_soon_threadsafe(queue.put_nowait, None)
+
+        threading.Thread(target=worker, daemon=True).start()
+
+        chunks: list[str] = []
+        start_time = perf_counter()
+        while True:
+            chunk = await queue.get()
+            if chunk is None:
+                break
+            text = getattr(chunk, "text", None)
+            if text:
+                chunks.append(text)
+                yield TextChunkEvent(content=text)
+
+        response = await final_future
+        end_time = perf_counter()
+        input_tokens, output_tokens, cached_tokens = _collect_usage_metadata(response)
+        input_cost, output_cost, cache_cost = _calculate_cost(
+            input_tokens,
+            output_tokens,
+            cached_tokens,
+            pricing_lookup,
+        )
+
+        final_text = "".join(chunks) or getattr(response, "text", "")
+        yield TextResponse(
+            response=final_text,
+            input_tokens=input_tokens,
+            output_tokens=output_tokens,
+            cache_read_tokens=cached_tokens,
+            input_cost=input_cost,
+            output_cost=output_cost,
+            cache_read_cost=cache_cost,
+            duration_seconds=end_time - start_time,
+        )
+
+
+@Client.register(RegisteredClients.GEMINI_TOOLS)
+class GeminiTools(Client):
+    """Wrapper around Gemini function calling support."""
+
+    def __init__(
+        self,
+        model_name: str,
+        tools: list[Tool],
+        tool_choice: ToolChoice = ToolChoice.REQUIRED,
+        api_key: str | None = None,
+        client_kwargs: dict[str, Any] | None = None,
+        **model_kwargs: object,
+    ) -> None:
+        if not tools:
+            raise ValueError("At least one tool must be provided for Gemini tools client.")
+        model_info = SUPPORTED_GEMINI_MODELS.get(model_name)
+        if not model_info or not model_info.supports_tools:
+            raise ValueError(f"Model '{model_name}' is not supported for Gemini tools.")
+
+        api_key_value = _ensure_api_key(api_key)
+        client_kwargs = client_kwargs or {}
+        client_kwargs.setdefault("api_key", api_key_value)
+        self.client = genai.Client(**client_kwargs)
+        self.model = model_info.model
+        self.model_parameters = {
+            key: value for key, value in model_kwargs.items() if value is not None
+        }
+        self.tools, self.declarations = _tools_to_gemini_tools(tools)
+        mode = "ANY" if tool_choice == ToolChoice.REQUIRED else "AUTO"
+        self.tool_config = types.ToolConfig(
+            function_calling_config=types.FunctionCallingConfig(mode=mode),
+        )
+
+    async def stream(
+        self,
+        messages: list[dict[str, Any]],
+    ) -> AsyncGenerator[ToolPredictionResponse, None]:
+        """Return Gemini tool predictions for a conversation."""
+        model_info = SUPPORTED_GEMINI_MODELS.get(self.model)
+        pricing_lookup = model_info.pricing if model_info else None
+
+        system_instruction, contents = _convert_messages(messages, cache_content=None)
+        parameters = _model_parameters_without_tools(self.model_parameters)
+        config = types.GenerateContentConfig(**parameters) if parameters else None
+        if config:
+            config.tools = self.tools
+            config.tool_config = self.tool_config
+        else:
+            config = types.GenerateContentConfig(
+                tools=self.tools,
+                tool_config=self.tool_config,
+            )
+
+        request_kwargs = {
+            "model": self.model,
+            "contents": contents,
+            "config": config,
+        }
+        if system_instruction:
+            request_kwargs["system_instruction"] = system_instruction
+
+        start_time = perf_counter()
+        response = await asyncio.to_thread(
+            self.client.models.generate_content,
+            **request_kwargs,
+        )
+        end_time = perf_counter()
+        input_tokens, output_tokens, cached_tokens = _collect_usage_metadata(response)
+        input_cost, output_cost, cache_cost = _calculate_cost(
+            input_tokens,
+            output_tokens,
+            cached_tokens,
+            pricing_lookup,
+        )
+
+        tool_prediction, message = _tool_response_to_prediction(response)
+
+        yield ToolPredictionResponse(
+            tool_prediction=tool_prediction,
+            message=message,
+            input_tokens=input_tokens,
+            output_tokens=output_tokens,
+            cache_read_tokens=cached_tokens,
+            input_cost=input_cost,
+            output_cost=output_cost,
+            cache_read_cost=cache_cost,
+            duration_seconds=end_time - start_time,
+        )
+
+
+def num_tokens(model_name: str, content: str) -> int:
+    """Return the token count for a single string using the Gemini tokenizer."""
+    api_key_value = _ensure_api_key(None)
+    client = genai.Client(api_key=api_key_value)
+    response = client.models.count_tokens(model=model_name, contents=content)
+    return getattr(response, "total_tokens", 0)
+
+
+def num_tokens_from_messages(model_name: str, messages: list[dict[str, Any]]) -> int:
+    """Return the token count for a message history."""
+    api_key_value = _ensure_api_key(None)
+    client = genai.Client(api_key=api_key_value)
+    _, contents = _convert_messages(messages, cache_content=None)
+    response = client.models.count_tokens(model=model_name, contents=contents)
+    return getattr(response, "total_tokens", 0)

--- a/src/sik_llms/models_base.py
+++ b/src/sik_llms/models_base.py
@@ -20,6 +20,7 @@ class ModelProvider(Enum):
 
     OPENAI = 'OpenAI'
     ANTHROPIC = 'Anthropic'
+    GOOGLE = 'Google'
     OTHER = 'Other'
 
 
@@ -30,6 +31,8 @@ class RegisteredClients(Enum):
     OPENAI_TOOLS = 'OpenAITools'
     ANTHROPIC = 'Anthropic'
     ANTHROPIC_TOOLS = 'AnthropicTools'
+    GEMINI = 'Gemini'
+    GEMINI_TOOLS = 'GeminiTools'
     REASONING_AGENT = 'ReasoningAgent'
 
 

--- a/src/sik_llms/reasoning_agent.py
+++ b/src/sik_llms/reasoning_agent.py
@@ -24,6 +24,7 @@ from sik_llms.models_base import (
 )
 from sik_llms.openai import SUPPORTED_OPENAI_MODELS
 from sik_llms.anthropic import SUPPORTED_ANTHROPIC_MODELS
+from sik_llms.gemini import SUPPORTED_GEMINI_MODELS
 
 
 PROMPT__REASONING_AGENT = resources.read_text('sik_llms.prompts', 'reasoning_prompt.txt')
@@ -53,6 +54,8 @@ def _get_client_type(model_name: str, client_type: str | Enum | None) -> str | E
         return RegisteredClients.OPENAI
     if model_name in SUPPORTED_ANTHROPIC_MODELS:
         return RegisteredClients.ANTHROPIC
+    if model_name in SUPPORTED_GEMINI_MODELS:
+        return RegisteredClients.GEMINI
     raise ValueError(f"Unknown model name '{model_name}' or client when trying to infer client type")  # noqa: E501
 
 
@@ -113,6 +116,8 @@ class ReasoningAgent(Client):
                     tools_client_type = RegisteredClients.OPENAI_TOOLS
                 elif client_type == RegisteredClients.ANTHROPIC:
                     tools_client_type = RegisteredClients.ANTHROPIC_TOOLS
+                elif client_type == RegisteredClients.GEMINI:
+                    tools_client_type = RegisteredClients.GEMINI_TOOLS
                 else:
                     raise ValueError("Unknown client type for tools when trying to infer tools_client_type")  # noqa: E501
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -31,6 +31,9 @@ OPENAI_TEST_REASONING_MODEL = 'o3-mini'
 ANTHROPIC_TEST_MODEL = 'claude-3-5-haiku'
 ANTRHOPIC_TEST_THINKING_MODEL = 'claude-3-7-sonnet'
 
+GEMINI_TEST_MODEL = 'gemini-2.5-flash'
+GEMINI_TEST_FUNCTION_CALLING = 'gemini-2.5-pro'
+
 
 @dataclass
 class ClientConfig:

--- a/tests/test_gemini.py
+++ b/tests/test_gemini.py
@@ -1,0 +1,191 @@
+"""Tests for Gemini integration."""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from typing import Any
+
+import pytest
+
+from pydantic import BaseModel
+
+from sik_llms import (
+    StructuredOutputResponse,
+    TextChunkEvent,
+    TextResponse,
+    create_client,
+    user_message,
+    Gemini,
+    GeminiTools,
+    Parameter,
+    RegisteredClients,
+    Tool,
+    SUPPORTED_GEMINI_MODELS,
+)
+from sik_llms.gemini import num_tokens
+from tests.conftest import GEMINI_TEST_MODEL, GEMINI_TEST_FUNCTION_CALLING
+from types import SimpleNamespace
+from google.genai import types
+
+MonkeyPatch = pytest.MonkeyPatch
+
+
+@pytest.fixture
+def anyio_backend() -> str:  # pragma: no cover - test configuration helper
+    return "asyncio"
+
+
+@pytest.fixture(autouse=True)
+def _patch_async_client(monkeypatch: MonkeyPatch) -> list[SimpleNamespace]:
+    """Provide a dummy AsyncClient for Gemini tests."""
+    instances = []
+
+    class DummyModels(SimpleNamespace):
+        pass
+
+    class DummyAsyncClient:
+        def __init__(self, **kwargs: object) -> None:
+            self.kwargs = kwargs
+            self.models = DummyModels()
+            instances.append(self)
+
+    monkeypatch.setenv("GOOGLE_API_KEY", "test-key")
+    monkeypatch.setattr("sik_llms.gemini.genai.Client", DummyAsyncClient)
+    return instances
+
+
+@pytest.mark.usefixtures("_patch_async_client")
+def test_create_client_returns_gemini() -> None:
+    """create_client should instantiate a Gemini client when model is supported."""
+    client = create_client(model_name=GEMINI_TEST_MODEL)
+    assert isinstance(client, Gemini)
+    assert client.model == SUPPORTED_GEMINI_MODELS[GEMINI_TEST_MODEL].model
+
+
+@pytest.mark.usefixtures("_patch_async_client")
+def test_client_instantiation_with_enum() -> None:
+    """Client.instantiate should handle RegisteredClients.GEMINI."""
+    client = create_client(
+        model_name=GEMINI_TEST_MODEL,
+        client_type=RegisteredClients.GEMINI,
+    )
+    assert isinstance(client, Gemini)
+
+
+@pytest.mark.usefixtures("_patch_async_client")
+def test_gemini_tools_configuration(monkeypatch: MonkeyPatch) -> None:
+    """GeminiTools should configure tool declarations and tool config."""
+    monkeypatch.setattr("sik_llms.gemini.genai.Client", lambda **_: SimpleNamespace())
+    tool = Tool(
+        name="add_numbers",
+        description="Add two integers.",
+        parameters=[
+            Parameter(name="a", param_type=int, required=True),
+            Parameter(name="b", param_type=int, required=True),
+        ],
+    )
+
+    client = GeminiTools(
+        model_name=GEMINI_TEST_FUNCTION_CALLING,
+        tools=[tool],
+    )
+
+    assert client.tool_config.function_calling_config.mode == "ANY"
+    declaration = client.declarations[0]
+    assert declaration.name == "add_numbers"
+    assert declaration.parameters.type == types.Type.OBJECT
+    assert "a" in declaration.parameters.properties
+    assert declaration.parameters.properties["a"].type == types.Type.INTEGER
+
+
+@pytest.mark.anyio("asyncio")
+@pytest.mark.usefixtures("_patch_async_client")
+async def test_gemini_streaming() -> None:
+    """Stream should yield chunk events followed by a TextResponse."""
+    client = create_client(model_name=GEMINI_TEST_MODEL)
+
+    class DummyStream:
+        def __iter__(self):  # pragma: no cover - simple iterator
+            yield SimpleNamespace(text="Hello")
+            yield SimpleNamespace(text=" world")
+
+        def get_final_response(self) -> SimpleNamespace:
+            usage = SimpleNamespace(
+                prompt_token_count=4,
+                candidates_token_count=3,
+                thoughts_token_count=0,
+                cached_content_token_count=0,
+            )
+            return SimpleNamespace(usage_metadata=usage, text="Hello world")
+
+    client.client.models.generate_content_stream = lambda **_kwargs: DummyStream()
+
+    chunks = []
+    final = None
+    async for event in client.stream(messages=[user_message("Say hi")]):
+        if isinstance(event, TextChunkEvent):
+            chunks.append(event.content)
+        else:
+            final = event
+
+    assert "".join(chunks) == "Hello world"
+    assert isinstance(final, TextResponse)
+    assert final.response == "Hello world"
+    assert final.input_tokens == 4
+    assert final.output_tokens == 3
+
+
+class _SummaryModel(BaseModel):
+    answer: str
+
+
+@pytest.mark.usefixtures("_patch_async_client")
+def test_gemini_structured_output(monkeypatch: MonkeyPatch) -> None:
+    """Structured output responses should return parsed Pydantic models."""
+
+    async def immediate_to_thread(
+        func: Callable[..., Any],
+        *args: object,
+        **kwargs: object,
+    ) -> object:  # pragma: no cover - helper
+        return func(*args, **kwargs)
+
+    monkeypatch.setattr("sik_llms.gemini.asyncio.to_thread", immediate_to_thread)
+
+    client = create_client(model_name=GEMINI_TEST_MODEL, response_format=_SummaryModel)
+
+    usage = SimpleNamespace(
+        prompt_token_count=10,
+        candidates_token_count=5,
+        thoughts_token_count=0,
+        cached_content_token_count=0,
+    )
+    response = SimpleNamespace(
+        parsed=_SummaryModel(answer="done"),
+        usage_metadata=usage,
+        candidates=[],
+    )
+    client.client.models.generate_content = lambda **_kwargs: response
+
+    result = client(messages=[user_message("Return summary")])
+    assert isinstance(result, StructuredOutputResponse)
+    assert isinstance(result.parsed, _SummaryModel)
+    assert result.parsed.answer == "done"
+    assert result.input_tokens == 10
+    assert result.output_tokens == 5
+
+
+def test_gemini_num_tokens(monkeypatch: MonkeyPatch) -> None:
+    """num_tokens should proxy through the Gemini SDK count call."""
+
+    class DummyCountClient:
+        def __init__(self, **_kwargs: object) -> None:
+            self.models = SimpleNamespace(
+                count_tokens=lambda *_args, **_kwargs: SimpleNamespace(total_tokens=42),
+            )
+
+    monkeypatch.setenv("GOOGLE_API_KEY", "test-key")
+    monkeypatch.setattr("sik_llms.gemini.genai.Client", DummyCountClient)
+
+    tokens = num_tokens(GEMINI_TEST_MODEL, "hello")
+    assert tokens == 42

--- a/uv.lock
+++ b/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 2
+revision = 3
 requires-python = ">=3.11"
 
 [[package]]
@@ -68,6 +68,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/5a/b0/1367933a8532ee6ff8d63537de4f1177af4bff9f3e829baf7331f595bb24/attrs-25.3.0.tar.gz", hash = "sha256:75d7cefc7fb576747b2c81b4442d4d4a1ce0900973527c011d1030fd3bf4af1b", size = 812032, upload-time = "2025-03-13T11:10:22.779Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/77/06/bb80f5f86020c4551da315d78b3ab75e8228f89f0162f2c3a819e407941a/attrs-25.3.0-py3-none-any.whl", hash = "sha256:427318ce031701fea540783410126f03899a97ffc6f61596ad581ac2e40e3bc3", size = 63815, upload-time = "2025-03-13T11:10:21.14Z" },
+]
+
+[[package]]
+name = "cachetools"
+version = "6.2.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/9d/61/e4fad8155db4a04bfb4734c7c8ff0882f078f24294d42798b3568eb63bff/cachetools-6.2.0.tar.gz", hash = "sha256:38b328c0889450f05f5e120f56ab68c8abaf424e1275522b138ffc93253f7e32", size = 30988, upload-time = "2025-08-25T18:57:30.924Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/6c/56/3124f61d37a7a4e7cc96afc5492c78ba0cb551151e530b54669ddd1436ef/cachetools-6.2.0-py3-none-any.whl", hash = "sha256:1c76a8960c0041fcc21097e357f882197c79da0dbff766e7317890a65d7d8ba6", size = 11276, upload-time = "2025-08-25T18:57:29.684Z" },
 ]
 
 [[package]]
@@ -265,6 +274,39 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/ce/5d/7797a74e8e31fa227f0303239802c5f09b6722bdb6638359e7b6c8f30004/faker-37.5.3.tar.gz", hash = "sha256:8315d8ff4d6f4f588bd42ffe63abd599886c785073e26a44707e10eeba5713dc", size = 1907147, upload-time = "2025-07-30T15:52:19.528Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/4b/bf/d06dd96e7afa72069dbdd26ed0853b5e8bd7941e2c0819a9b21d6e6fc052/faker-37.5.3-py3-none-any.whl", hash = "sha256:386fe9d5e6132a915984bf887fcebcc72d6366a25dd5952905b31b141a17016d", size = 1949261, upload-time = "2025-07-30T15:52:17.729Z" },
+]
+
+[[package]]
+name = "google-auth"
+version = "2.41.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cachetools" },
+    { name = "pyasn1-modules" },
+    { name = "rsa" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/a8/af/5129ce5b2f9688d2fa49b463e544972a7c82b0fdb50980dafee92e121d9f/google_auth-2.41.1.tar.gz", hash = "sha256:b76b7b1f9e61f0cb7e88870d14f6a94aeef248959ef6992670efee37709cbfd2", size = 292284, upload-time = "2025-09-30T22:51:26.363Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/be/a4/7319a2a8add4cc352be9e3efeff5e2aacee917c85ca2fa1647e29089983c/google_auth-2.41.1-py2.py3-none-any.whl", hash = "sha256:754843be95575b9a19c604a848a41be03f7f2afd8c019f716dc1f51ee41c639d", size = 221302, upload-time = "2025-09-30T22:51:24.212Z" },
+]
+
+[[package]]
+name = "google-genai"
+version = "1.41.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+    { name = "google-auth" },
+    { name = "httpx" },
+    { name = "pydantic" },
+    { name = "requests" },
+    { name = "tenacity" },
+    { name = "typing-extensions" },
+    { name = "websockets" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/72/8b/ee20bcf707769b3b0e1106c3b5c811507736af7e8a60f29a70af1750ba19/google_genai-1.41.0.tar.gz", hash = "sha256:134f861bb0ace4e34af0501ecb75ceee15f7662fd8120698cd185e8cb39f2800", size = 245812, upload-time = "2025-10-02T22:30:29.699Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/15/14/e5e8fbca8863fee718208566c4e927b8e9f45fd46ec5cf89e24759da545b/google_genai-1.41.0-py3-none-any.whl", hash = "sha256:111a3ee64c1a0927d3879faddb368234594432479a40c311e5fe4db338ca8778", size = 245931, upload-time = "2025-10-02T22:30:27.885Z" },
 ]
 
 [[package]]
@@ -707,6 +749,27 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/cd/05/0a34433a064256a578f1783a10da6df098ceaa4a57bbeaa96a6c0352786b/pure_eval-0.2.3.tar.gz", hash = "sha256:5f4e983f40564c576c7c8635ae88db5956bb2229d7e9237d03b3c0b0190eaf42", size = 19752, upload-time = "2024-07-21T12:58:21.801Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/8e/37/efad0257dc6e593a18957422533ff0f87ede7c9c6ea010a2177d738fb82f/pure_eval-0.2.3-py3-none-any.whl", hash = "sha256:1db8e35b67b3d218d818ae653e27f06c3aa420901fa7b081ca98cbedc874e0d0", size = 11842, upload-time = "2024-07-21T12:58:20.04Z" },
+]
+
+[[package]]
+name = "pyasn1"
+version = "0.6.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/ba/e9/01f1a64245b89f039897cb0130016d79f77d52669aae6ee7b159a6c4c018/pyasn1-0.6.1.tar.gz", hash = "sha256:6f580d2bdd84365380830acf45550f2511469f673cb4a5ae3857a3170128b034", size = 145322, upload-time = "2024-09-10T22:41:42.55Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c8/f1/d6a797abb14f6283c0ddff96bbdd46937f64122b8c925cab503dd37f8214/pyasn1-0.6.1-py3-none-any.whl", hash = "sha256:0d632f46f2ba09143da3a8afe9e33fb6f92fa2320ab7e886e2d0f7672af84629", size = 83135, upload-time = "2024-09-11T16:00:36.122Z" },
+]
+
+[[package]]
+name = "pyasn1-modules"
+version = "0.4.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyasn1" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/e9/e6/78ebbb10a8c8e4b61a59249394a4a594c1a7af95593dc933a349c8d00964/pyasn1_modules-0.4.2.tar.gz", hash = "sha256:677091de870a80aae844b1ca6134f54652fa2c8c5a52aa396440ac3106e941e6", size = 307892, upload-time = "2025-03-28T02:41:22.17Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/47/8d/d529b5d697919ba8c11ad626e835d4039be708a35b0d22de83a269a6682c/pyasn1_modules-0.4.2-py3-none-any.whl", hash = "sha256:29253a9207ce32b64c3ac6600edc75368f98473906e8fd1043bd6b5b1de2c14a", size = 181259, upload-time = "2025-03-28T02:41:19.028Z" },
 ]
 
 [[package]]
@@ -1183,6 +1246,18 @@ wheels = [
 ]
 
 [[package]]
+name = "rsa"
+version = "4.9.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyasn1" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/da/8a/22b7beea3ee0d44b1916c0c1cb0ee3af23b700b6da9f04991899d0c555d4/rsa-4.9.1.tar.gz", hash = "sha256:e7bdbfdb5497da4c07dfd35530e1a902659db6ff241e39d9953cad06ebd0ae75", size = 29034, upload-time = "2025-04-16T09:51:18.218Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/64/8d/0133e4eb4beed9e425d9a98ed6e081a55d195481b7632472be1af08d2f6b/rsa-4.9.1-py3-none-any.whl", hash = "sha256:68635866661c6836b8d39430f97a996acbd61bfa49406748ea243539fe239762", size = 34696, upload-time = "2025-04-16T09:51:17.142Z" },
+]
+
+[[package]]
 name = "ruff"
 version = "0.12.8"
 source = { registry = "https://pypi.org/simple" }
@@ -1222,6 +1297,7 @@ version = "0.3.25"
 source = { editable = "." }
 dependencies = [
     { name = "anthropic" },
+    { name = "google-genai" },
     { name = "mcp", extra = ["cli"] },
     { name = "nest-asyncio" },
     { name = "openai" },
@@ -1245,6 +1321,7 @@ dev = [
 [package.metadata]
 requires-dist = [
     { name = "anthropic", specifier = ">=0.62.0" },
+    { name = "google-genai", specifier = ">=1.41.0" },
     { name = "mcp", extras = ["cli"], specifier = ">=1.12.4" },
     { name = "nest-asyncio", specifier = ">=1.6.0" },
     { name = "openai", specifier = ">=1.99.6" },
@@ -1334,6 +1411,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/04/57/d062573f391d062710d4088fa1369428c38d51460ab6fedff920efef932e/starlette-0.47.2.tar.gz", hash = "sha256:6ae9aa5db235e4846decc1e7b79c4f346adf41e9777aebeb49dfd09bbd7023d8", size = 2583948, upload-time = "2025-07-20T17:31:58.522Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/f7/1f/b876b1f83aef204198a42dc101613fefccb32258e5428b5f9259677864b4/starlette-0.47.2-py3-none-any.whl", hash = "sha256:c5847e96134e5c5371ee9fac6fdf1a67336d5815e09eb2a01fdb57a351ef915b", size = 72984, upload-time = "2025-07-20T17:31:56.738Z" },
+]
+
+[[package]]
+name = "tenacity"
+version = "9.1.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/0a/d4/2b0cd0fe285e14b36db076e78c93766ff1d529d70408bd1d2a5a84f1d929/tenacity-9.1.2.tar.gz", hash = "sha256:1169d376c297e7de388d18b4481760d478b0e99a777cad3a9c86e556f4b697cb", size = 48036, upload-time = "2025-04-02T08:25:09.966Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e5/30/643397144bfbfec6f6ef821f36f33e57d35946c44a2352d3c9f0ae847619/tenacity-9.1.2-py3-none-any.whl", hash = "sha256:f77bf36710d8b73a50b2dd155c97b870017ad21afe6ab300326b0371b3b05138", size = 28248, upload-time = "2025-04-02T08:25:07.678Z" },
 ]
 
 [[package]]
@@ -1480,4 +1566,46 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/6c/63/53559446a878410fc5a5974feb13d31d78d752eb18aeba59c7fef1af7598/wcwidth-0.2.13.tar.gz", hash = "sha256:72ea0c06399eb286d978fdedb6923a9eb47e1c486ce63e9b4e64fc18303972b5", size = 101301, upload-time = "2024-01-06T02:10:57.829Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/fd/84/fd2ba7aafacbad3c4201d395674fc6348826569da3c0937e75505ead3528/wcwidth-0.2.13-py2.py3-none-any.whl", hash = "sha256:3da69048e4540d84af32131829ff948f1e022c1c6bdb8d6102117aac784f6859", size = 34166, upload-time = "2024-01-06T02:10:55.763Z" },
+]
+
+[[package]]
+name = "websockets"
+version = "15.0.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/21/e6/26d09fab466b7ca9c7737474c52be4f76a40301b08362eb2dbc19dcc16c1/websockets-15.0.1.tar.gz", hash = "sha256:82544de02076bafba038ce055ee6412d68da13ab47f0c60cab827346de828dee", size = 177016, upload-time = "2025-03-05T20:03:41.606Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9f/32/18fcd5919c293a398db67443acd33fde142f283853076049824fc58e6f75/websockets-15.0.1-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:823c248b690b2fd9303ba00c4f66cd5e2d8c3ba4aa968b2779be9532a4dad431", size = 175423, upload-time = "2025-03-05T20:01:56.276Z" },
+    { url = "https://files.pythonhosted.org/packages/76/70/ba1ad96b07869275ef42e2ce21f07a5b0148936688c2baf7e4a1f60d5058/websockets-15.0.1-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:678999709e68425ae2593acf2e3ebcbcf2e69885a5ee78f9eb80e6e371f1bf57", size = 173082, upload-time = "2025-03-05T20:01:57.563Z" },
+    { url = "https://files.pythonhosted.org/packages/86/f2/10b55821dd40eb696ce4704a87d57774696f9451108cff0d2824c97e0f97/websockets-15.0.1-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:d50fd1ee42388dcfb2b3676132c78116490976f1300da28eb629272d5d93e905", size = 173330, upload-time = "2025-03-05T20:01:59.063Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/90/1c37ae8b8a113d3daf1065222b6af61cc44102da95388ac0018fcb7d93d9/websockets-15.0.1-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:d99e5546bf73dbad5bf3547174cd6cb8ba7273062a23808ffea025ecb1cf8562", size = 182878, upload-time = "2025-03-05T20:02:00.305Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/8d/96e8e288b2a41dffafb78e8904ea7367ee4f891dafc2ab8d87e2124cb3d3/websockets-15.0.1-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:66dd88c918e3287efc22409d426c8f729688d89a0c587c88971a0faa2c2f3792", size = 181883, upload-time = "2025-03-05T20:02:03.148Z" },
+    { url = "https://files.pythonhosted.org/packages/93/1f/5d6dbf551766308f6f50f8baf8e9860be6182911e8106da7a7f73785f4c4/websockets-15.0.1-cp311-cp311-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:8dd8327c795b3e3f219760fa603dcae1dcc148172290a8ab15158cf85a953413", size = 182252, upload-time = "2025-03-05T20:02:05.29Z" },
+    { url = "https://files.pythonhosted.org/packages/d4/78/2d4fed9123e6620cbf1706c0de8a1632e1a28e7774d94346d7de1bba2ca3/websockets-15.0.1-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:8fdc51055e6ff4adeb88d58a11042ec9a5eae317a0a53d12c062c8a8865909e8", size = 182521, upload-time = "2025-03-05T20:02:07.458Z" },
+    { url = "https://files.pythonhosted.org/packages/e7/3b/66d4c1b444dd1a9823c4a81f50231b921bab54eee2f69e70319b4e21f1ca/websockets-15.0.1-cp311-cp311-musllinux_1_2_i686.whl", hash = "sha256:693f0192126df6c2327cce3baa7c06f2a117575e32ab2308f7f8216c29d9e2e3", size = 181958, upload-time = "2025-03-05T20:02:09.842Z" },
+    { url = "https://files.pythonhosted.org/packages/08/ff/e9eed2ee5fed6f76fdd6032ca5cd38c57ca9661430bb3d5fb2872dc8703c/websockets-15.0.1-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:54479983bd5fb469c38f2f5c7e3a24f9a4e70594cd68cd1fa6b9340dadaff7cf", size = 181918, upload-time = "2025-03-05T20:02:11.968Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/75/994634a49b7e12532be6a42103597b71098fd25900f7437d6055ed39930a/websockets-15.0.1-cp311-cp311-win32.whl", hash = "sha256:16b6c1b3e57799b9d38427dda63edcbe4926352c47cf88588c0be4ace18dac85", size = 176388, upload-time = "2025-03-05T20:02:13.32Z" },
+    { url = "https://files.pythonhosted.org/packages/98/93/e36c73f78400a65f5e236cd376713c34182e6663f6889cd45a4a04d8f203/websockets-15.0.1-cp311-cp311-win_amd64.whl", hash = "sha256:27ccee0071a0e75d22cb35849b1db43f2ecd3e161041ac1ee9d2352ddf72f065", size = 176828, upload-time = "2025-03-05T20:02:14.585Z" },
+    { url = "https://files.pythonhosted.org/packages/51/6b/4545a0d843594f5d0771e86463606a3988b5a09ca5123136f8a76580dd63/websockets-15.0.1-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:3e90baa811a5d73f3ca0bcbf32064d663ed81318ab225ee4f427ad4e26e5aff3", size = 175437, upload-time = "2025-03-05T20:02:16.706Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/71/809a0f5f6a06522af902e0f2ea2757f71ead94610010cf570ab5c98e99ed/websockets-15.0.1-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:592f1a9fe869c778694f0aa806ba0374e97648ab57936f092fd9d87f8bc03665", size = 173096, upload-time = "2025-03-05T20:02:18.832Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/69/1a681dd6f02180916f116894181eab8b2e25b31e484c5d0eae637ec01f7c/websockets-15.0.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:0701bc3cfcb9164d04a14b149fd74be7347a530ad3bbf15ab2c678a2cd3dd9a2", size = 173332, upload-time = "2025-03-05T20:02:20.187Z" },
+    { url = "https://files.pythonhosted.org/packages/a6/02/0073b3952f5bce97eafbb35757f8d0d54812b6174ed8dd952aa08429bcc3/websockets-15.0.1-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:e8b56bdcdb4505c8078cb6c7157d9811a85790f2f2b3632c7d1462ab5783d215", size = 183152, upload-time = "2025-03-05T20:02:22.286Z" },
+    { url = "https://files.pythonhosted.org/packages/74/45/c205c8480eafd114b428284840da0b1be9ffd0e4f87338dc95dc6ff961a1/websockets-15.0.1-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:0af68c55afbd5f07986df82831c7bff04846928ea8d1fd7f30052638788bc9b5", size = 182096, upload-time = "2025-03-05T20:02:24.368Z" },
+    { url = "https://files.pythonhosted.org/packages/14/8f/aa61f528fba38578ec553c145857a181384c72b98156f858ca5c8e82d9d3/websockets-15.0.1-cp312-cp312-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:64dee438fed052b52e4f98f76c5790513235efaa1ef7f3f2192c392cd7c91b65", size = 182523, upload-time = "2025-03-05T20:02:25.669Z" },
+    { url = "https://files.pythonhosted.org/packages/ec/6d/0267396610add5bc0d0d3e77f546d4cd287200804fe02323797de77dbce9/websockets-15.0.1-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:d5f6b181bb38171a8ad1d6aa58a67a6aa9d4b38d0f8c5f496b9e42561dfc62fe", size = 182790, upload-time = "2025-03-05T20:02:26.99Z" },
+    { url = "https://files.pythonhosted.org/packages/02/05/c68c5adbf679cf610ae2f74a9b871ae84564462955d991178f95a1ddb7dd/websockets-15.0.1-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:5d54b09eba2bada6011aea5375542a157637b91029687eb4fdb2dab11059c1b4", size = 182165, upload-time = "2025-03-05T20:02:30.291Z" },
+    { url = "https://files.pythonhosted.org/packages/29/93/bb672df7b2f5faac89761cb5fa34f5cec45a4026c383a4b5761c6cea5c16/websockets-15.0.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:3be571a8b5afed347da347bfcf27ba12b069d9d7f42cb8c7028b5e98bbb12597", size = 182160, upload-time = "2025-03-05T20:02:31.634Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/83/de1f7709376dc3ca9b7eeb4b9a07b4526b14876b6d372a4dc62312bebee0/websockets-15.0.1-cp312-cp312-win32.whl", hash = "sha256:c338ffa0520bdb12fbc527265235639fb76e7bc7faafbb93f6ba80d9c06578a9", size = 176395, upload-time = "2025-03-05T20:02:33.017Z" },
+    { url = "https://files.pythonhosted.org/packages/7d/71/abf2ebc3bbfa40f391ce1428c7168fb20582d0ff57019b69ea20fa698043/websockets-15.0.1-cp312-cp312-win_amd64.whl", hash = "sha256:fcd5cf9e305d7b8338754470cf69cf81f420459dbae8a3b40cee57417f4614a7", size = 176841, upload-time = "2025-03-05T20:02:34.498Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/9f/51f0cf64471a9d2b4d0fc6c534f323b664e7095640c34562f5182e5a7195/websockets-15.0.1-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:ee443ef070bb3b6ed74514f5efaa37a252af57c90eb33b956d35c8e9c10a1931", size = 175440, upload-time = "2025-03-05T20:02:36.695Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/05/aa116ec9943c718905997412c5989f7ed671bc0188ee2ba89520e8765d7b/websockets-15.0.1-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:5a939de6b7b4e18ca683218320fc67ea886038265fd1ed30173f5ce3f8e85675", size = 173098, upload-time = "2025-03-05T20:02:37.985Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/0b/33cef55ff24f2d92924923c99926dcce78e7bd922d649467f0eda8368923/websockets-15.0.1-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:746ee8dba912cd6fc889a8147168991d50ed70447bf18bcda7039f7d2e3d9151", size = 173329, upload-time = "2025-03-05T20:02:39.298Z" },
+    { url = "https://files.pythonhosted.org/packages/31/1d/063b25dcc01faa8fada1469bdf769de3768b7044eac9d41f734fd7b6ad6d/websockets-15.0.1-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:595b6c3969023ecf9041b2936ac3827e4623bfa3ccf007575f04c5a6aa318c22", size = 183111, upload-time = "2025-03-05T20:02:40.595Z" },
+    { url = "https://files.pythonhosted.org/packages/93/53/9a87ee494a51bf63e4ec9241c1ccc4f7c2f45fff85d5bde2ff74fcb68b9e/websockets-15.0.1-cp313-cp313-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:3c714d2fc58b5ca3e285461a4cc0c9a66bd0e24c5da9911e30158286c9b5be7f", size = 182054, upload-time = "2025-03-05T20:02:41.926Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/b2/83a6ddf56cdcbad4e3d841fcc55d6ba7d19aeb89c50f24dd7e859ec0805f/websockets-15.0.1-cp313-cp313-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:0f3c1e2ab208db911594ae5b4f79addeb3501604a165019dd221c0bdcabe4db8", size = 182496, upload-time = "2025-03-05T20:02:43.304Z" },
+    { url = "https://files.pythonhosted.org/packages/98/41/e7038944ed0abf34c45aa4635ba28136f06052e08fc2168520bb8b25149f/websockets-15.0.1-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:229cf1d3ca6c1804400b0a9790dc66528e08a6a1feec0d5040e8b9eb14422375", size = 182829, upload-time = "2025-03-05T20:02:48.812Z" },
+    { url = "https://files.pythonhosted.org/packages/e0/17/de15b6158680c7623c6ef0db361da965ab25d813ae54fcfeae2e5b9ef910/websockets-15.0.1-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:756c56e867a90fb00177d530dca4b097dd753cde348448a1012ed6c5131f8b7d", size = 182217, upload-time = "2025-03-05T20:02:50.14Z" },
+    { url = "https://files.pythonhosted.org/packages/33/2b/1f168cb6041853eef0362fb9554c3824367c5560cbdaad89ac40f8c2edfc/websockets-15.0.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:558d023b3df0bffe50a04e710bc87742de35060580a293c2a984299ed83bc4e4", size = 182195, upload-time = "2025-03-05T20:02:51.561Z" },
+    { url = "https://files.pythonhosted.org/packages/86/eb/20b6cdf273913d0ad05a6a14aed4b9a85591c18a987a3d47f20fa13dcc47/websockets-15.0.1-cp313-cp313-win32.whl", hash = "sha256:ba9e56e8ceeeedb2e080147ba85ffcd5cd0711b89576b83784d8605a7df455fa", size = 176393, upload-time = "2025-03-05T20:02:53.814Z" },
+    { url = "https://files.pythonhosted.org/packages/1b/6c/c65773d6cab416a64d191d6ee8a8b1c68a09970ea6909d16965d26bfed1e/websockets-15.0.1-cp313-cp313-win_amd64.whl", hash = "sha256:e09473f095a819042ecb2ab9465aee615bd9c2028e4ef7d933600a8401c79561", size = 176837, upload-time = "2025-03-05T20:02:55.237Z" },
+    { url = "https://files.pythonhosted.org/packages/fa/a8/5b41e0da817d64113292ab1f8247140aac61cbf6cfd085d6a0fa77f4984f/websockets-15.0.1-py3-none-any.whl", hash = "sha256:f7a866fbc1e97b5c617ee4116daaa09b722101d4a3c170c787450ba409f9736f", size = 169743, upload-time = "2025-03-05T20:03:39.41Z" },
 ]


### PR DESCRIPTION
## Summary
- add Gemini provider implementation and registry wiring
- document Google API key setup and usage
- expand tests for Gemini clients and ReasoningAgent routing

## Testing
- ~/.local/bin/pytest tests/test_gemini.py
- ~/.local/bin/pytest tests/test_reasoning_agent.py::test_reasoning_agent_uses_gemini_clients
- ~/.local/bin/pytest tests/test_sik_llms.py::test__create_client__gemini
