### PR TITLE
Support parallel tool calls in Anthropic and OpenAI

### DIFF
--- a/examples/examples.ipynb
+++ b/examples/examples.ipynb
@@ -413,51 +413,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 14,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "input_tokens=141 output_tokens=89 input_cost=3.5249999999999996e-05 output_cost=0.000178 cache_write_tokens=None cache_read_tokens=0 cache_write_cost=None cache_read_cost=0.0 duration_seconds=1.85469154198654 tool_prediction=ToolPrediction(name='get_weather', arguments={'location': 'Paris, France'}, call_id='call_xvtWMQSARmodw5bee1elKPfv') message=None\n",
-      "---\n",
-      "name='get_weather' arguments={'location': 'Paris, France'} call_id='call_xvtWMQSARmodw5bee1elKPfv'\n"
-     ]
-    }
-   ],
-   "source": [
-    "from sik_llms import (\n",
-    "    create_client, user_message,\n",
-    "    Tool, Parameter, RegisteredClients,\n",
-    ")\n",
-    "\n",
-    "weather_tool = Tool(\n",
-    "    name='get_weather',\n",
-    "    description=\"Get the weather for a location.\",\n",
-    "    parameters=[\n",
-    "        Parameter(\n",
-    "            name='location',\n",
-    "            param_type=str,\n",
-    "            required=True,\n",
-    "            description='The city and country for weather info.',\n",
-    "        ),\n",
-    "    ],\n",
-    ")\n",
-    "\n",
-    "client = create_client(\n",
-    "    client_type=RegisteredClients.OPENAI_TOOLS,\n",
-    "    model_name=OPENAI_MODEL,\n",
-    "    tools=[weather_tool],\n",
-    ")\n",
-    "\n",
-    "message = user_message(\"What is the weather in Paris?\")\n",
-    "response = await client.run_async(messages=[message])\n",
-    "# or `response = client(messages=[message])` for synchronous execution\n",
-    "print(response)\n",
-    "print('---')\n",
-    "print(response.tool_prediction)"
-   ]
+   "outputs": [],
+   "source": "from sik_llms import (\n    create_client, user_message,\n    Tool, Parameter, RegisteredClients,\n)\n\nweather_tool = Tool(\n    name='get_weather',\n    description=\"Get the weather for a location.\",\n    parameters=[\n        Parameter(\n            name='location',\n            param_type=str,\n            required=True,\n            description='The city and country for weather info.',\n        ),\n    ],\n)\n\nclient = create_client(\n    client_type=RegisteredClients.OPENAI_TOOLS,\n    model_name=OPENAI_MODEL,\n    tools=[weather_tool],\n)\n\nmessage = user_message(\"What is the weather in Paris?\")\nresponse = await client.run_async(messages=[message])\n# or `response = client(messages=[message])` for synchronous execution\nprint(response)\nprint('---')\nprint(response.tool_predictions)"
   },
   {
    "cell_type": "markdown",
@@ -475,51 +434,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 15,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "input_tokens=402 output_tokens=40 input_cost=0.001206 output_cost=0.0006000000000000001 cache_write_tokens=0 cache_read_tokens=0 cache_write_cost=0.0 cache_read_cost=0.0 duration_seconds=1.1365794580196962 tool_prediction=ToolPrediction(name='get_weather', arguments={'location': 'Paris, France'}, call_id='toolu_01SZbbKwFk2JeCgiRhwwrj6m') message=None\n",
-      "---\n",
-      "name='get_weather' arguments={'location': 'Paris, France'} call_id='toolu_01SZbbKwFk2JeCgiRhwwrj6m'\n"
-     ]
-    }
-   ],
-   "source": [
-    "from sik_llms import (\n",
-    "    create_client, user_message,\n",
-    "    Tool, Parameter, RegisteredClients,\n",
-    ")\n",
-    "\n",
-    "weather_tool = Tool(\n",
-    "    name='get_weather',\n",
-    "    description=\"Get the weather for a location.\",\n",
-    "    parameters=[\n",
-    "        Parameter(\n",
-    "            name='location',\n",
-    "            param_type=str,\n",
-    "            required=True,\n",
-    "            description='The city and country for weather info.',\n",
-    "        ),\n",
-    "    ],\n",
-    ")\n",
-    "\n",
-    "client = create_client(\n",
-    "    client_type=RegisteredClients.ANTHROPIC_TOOLS,\n",
-    "    model_name=CLAUDE_MODEL,\n",
-    "    tools=[weather_tool],\n",
-    ")\n",
-    "\n",
-    "message = user_message(\"What is the weather in Paris?\")\n",
-    "response = await client.run_async(messages=[message])\n",
-    "# or `response = client(messages=[message])` for synchronous execution\n",
-    "print(response)\n",
-    "print('---')\n",
-    "print(response.tool_prediction)"
-   ]
+   "outputs": [],
+   "source": "from sik_llms import (\n    create_client, user_message,\n    Tool, Parameter, RegisteredClients,\n)\n\nweather_tool = Tool(\n    name='get_weather',\n    description=\"Get the weather for a location.\",\n    parameters=[\n        Parameter(\n            name='location',\n            param_type=str,\n            required=True,\n            description='The city and country for weather info.',\n        ),\n    ],\n)\n\nclient = create_client(\n    client_type=RegisteredClients.ANTHROPIC_TOOLS,\n    model_name=CLAUDE_MODEL,\n    tools=[weather_tool],\n)\n\nmessage = user_message(\"What is the weather in Paris?\")\nresponse = await client.run_async(messages=[message])\n# or `response = client(messages=[message])` for synchronous execution\nprint(response)\nprint('---')\nprint(response.tool_predictions)"
   },
   {
    "cell_type": "markdown",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "sik-llms"
-version = "0.3.29"
+version = "0.3.30"
 description = "Lightweight, easy, and consistent LLM-interface across providers and functionality."
 readme = "README.md"
 requires-python = ">=3.11"

--- a/src/sik_llms/anthropic.py
+++ b/src/sik_llms/anthropic.py
@@ -536,10 +536,10 @@ class Anthropic(Client):
                 refusal = None
                 response = await functions_client.run_async(messages)
                 # Extract function call result and convert to Pydantic model
-                if response.tool_prediction:
+                if response.tool_predictions:
                     try:
                         # Create instance of Pydantic model from arguments
-                        parsed = self.response_format(**response.tool_prediction.arguments)
+                        parsed = self.response_format(**response.tool_predictions[0].arguments)
                     except Exception as e:
                         # If conversion fails, set refusal with error message
                         refusal=f"Failed to parse response: response={response}, error={e!s}"

--- a/src/sik_llms/anthropic.py
+++ b/src/sik_llms/anthropic.py
@@ -828,20 +828,17 @@ class AnthropicTools(Client):
         response = await self.client.messages.create(**api_params)
         end_time = perf_counter()
 
-        tool_prediction = None
+        tool_predictions = []
         message = None
-        if len(response.content) > 1:
-            raise ValueError(f"Unexpected multiple content items in response: {response.content}")
-        if response.content[0].type == 'tool_use':
-            tool_prediction = ToolPrediction(
-                name=response.content[0].name,
-                arguments=response.content[0].input,
-                call_id=response.content[0].id,
-            )
-        elif response.content[0].type == 'text':
-            message = response.content[0].text
-        else:
-            raise ValueError(f"Unexpected content type: {response.content[0].type}")
+        for content_item in response.content:
+            if content_item.type == 'tool_use':
+                tool_predictions.append(ToolPrediction(
+                    name=content_item.name,
+                    arguments=content_item.input,
+                    call_id=content_item.id,
+                ))
+            elif content_item.type == 'text':
+                message = content_item.text
 
         pricing_lookup = SUPPORTED_ANTHROPIC_MODELS[self.model].pricing
         input_tokens = response.usage.input_tokens
@@ -849,7 +846,7 @@ class AnthropicTools(Client):
         cache_creation_input_tokens = response.usage.cache_creation_input_tokens
         cache_read_input_tokens = response.usage.cache_read_input_tokens
         yield ToolPredictionResponse(
-            tool_prediction=tool_prediction,
+            tool_predictions=tool_predictions,
             message=message,
             input_tokens=input_tokens,
             output_tokens=output_tokens,

--- a/src/sik_llms/anthropic.py
+++ b/src/sik_llms/anthropic.py
@@ -147,6 +147,24 @@ ANTHROPIC_MODEL_LOOKUPS = [
     ),
 
     ModelInfo(
+        model='claude-sonnet-4-6',
+        provider=ModelProvider.ANTHROPIC,
+        max_output_tokens=64_000,
+        context_window_size=200_000,
+        pricing={
+            'input': 3.00 / 1_000_000, 'output': 15.00 / 1_000_000,
+            'cache_write': 3.75 / 1_000_000, 'cache_read': 0.30 / 1_000_000,
+        },
+        supports_tools=True,
+        supports_images=True,
+        supports_reasoning=True,
+        knowledge_cutoff_date=date(year=2025, month=8, day=1),
+        metadata={
+            'max_output_extended_thinking': 64_000,
+        },
+    ),
+
+    ModelInfo(
         model='claude-opus-4-20250514',
         provider=ModelProvider.ANTHROPIC,
         max_output_tokens=32_000,
@@ -223,9 +241,9 @@ SUPPORTED_ANTHROPIC_MODELS = {model.model: model for model in ANTHROPIC_MODEL_LO
 # SUPPORTED_ANTHROPIC_MODELS['claude-3-5-haiku'] = SUPPORTED_ANTHROPIC_MODELS['claude-3-5-haiku-20241022']  # noqa: E501
 # SUPPORTED_ANTHROPIC_MODELS['claude-3-7-sonnet'] = SUPPORTED_ANTHROPIC_MODELS['claude-3-7-sonnet-20250219']  # noqa: E501
 SUPPORTED_ANTHROPIC_MODELS['claude-haiku-4-5'] = SUPPORTED_ANTHROPIC_MODELS['claude-haiku-4-5-20251001']  # noqa: E501
-SUPPORTED_ANTHROPIC_MODELS['claude-sonnet-4'] = SUPPORTED_ANTHROPIC_MODELS['claude-sonnet-4-20250514']  # noqa: E501
+SUPPORTED_ANTHROPIC_MODELS['claude-sonnet-4-0'] = SUPPORTED_ANTHROPIC_MODELS['claude-sonnet-4-20250514']  # noqa: E501
 SUPPORTED_ANTHROPIC_MODELS['claude-sonnet-4-5'] = SUPPORTED_ANTHROPIC_MODELS['claude-sonnet-4-5-20250929']  # noqa: E501
-SUPPORTED_ANTHROPIC_MODELS['claude-opus-4'] = SUPPORTED_ANTHROPIC_MODELS['claude-opus-4-20250514']
+SUPPORTED_ANTHROPIC_MODELS['claude-opus-4-0'] = SUPPORTED_ANTHROPIC_MODELS['claude-opus-4-20250514']  # noqa: E501
 SUPPORTED_ANTHROPIC_MODELS['claude-opus-4-1'] = SUPPORTED_ANTHROPIC_MODELS['claude-opus-4-1-20250805']  # noqa: E501
 SUPPORTED_ANTHROPIC_MODELS['claude-opus-4-5'] = SUPPORTED_ANTHROPIC_MODELS['claude-opus-4-5-20251101']  # noqa: E501
 ANTHROPIC_MODEL_NAMES = list(SUPPORTED_ANTHROPIC_MODELS.keys())

--- a/src/sik_llms/models_base.py
+++ b/src/sik_llms/models_base.py
@@ -476,17 +476,11 @@ class ToolPredictionResponse(TokenSummary):
     If no tool call is predicted, then tool_prediction is None and message is filled.
 
     When the model returns multiple tool calls (parallel tool use), all calls are available
-    in `tool_predictions`. The `tool_prediction` field returns the first one for backwards
-    compatibility.
+    in `tool_predictions`.
     """
 
     tool_predictions: list[ToolPrediction] = []
     message: str | None = None
-
-    @property
-    def tool_prediction(self) -> ToolPrediction | None:
-        """Return the first tool prediction, or None if there are no predictions."""
-        return self.tool_predictions[0] if self.tool_predictions else None
 
 
 ClientType = TypeVar('ClientType', bound='Client')

--- a/src/sik_llms/models_base.py
+++ b/src/sik_llms/models_base.py
@@ -472,12 +472,21 @@ class ToolPredictionResponse(TokenSummary):
 
     Content is filled if there is no function/call.
 
-    If a tool call is predicted, then tool_call is filled and message is None.
-    If no tool call is predicted, then tool_call is None and message is filled.
+    If a tool call is predicted, then tool_prediction is filled and message is None.
+    If no tool call is predicted, then tool_prediction is None and message is filled.
+
+    When the model returns multiple tool calls (parallel tool use), all calls are available
+    in `tool_predictions`. The `tool_prediction` field returns the first one for backwards
+    compatibility.
     """
 
-    tool_prediction: ToolPrediction | None
+    tool_predictions: list[ToolPrediction] = []
     message: str | None = None
+
+    @property
+    def tool_prediction(self) -> ToolPrediction | None:
+        """Return the first tool prediction, or None if there are no predictions."""
+        return self.tool_predictions[0] if self.tool_predictions else None
 
 
 ClientType = TypeVar('ClientType', bound='Client')

--- a/src/sik_llms/models_base.py
+++ b/src/sik_llms/models_base.py
@@ -472,11 +472,8 @@ class ToolPredictionResponse(TokenSummary):
 
     Content is filled if there is no function/call.
 
-    If a tool call is predicted, then tool_prediction is filled and message is None.
-    If no tool call is predicted, then tool_prediction is None and message is filled.
-
-    When the model returns multiple tool calls (parallel tool use), all calls are available
-    in `tool_predictions`.
+    If tool calls are predicted, `tool_predictions` is non-empty and `message` is None.
+    If no tool calls are predicted, `tool_predictions` is empty and `message` is filled.
     """
 
     tool_predictions: list[ToolPrediction] = []

--- a/src/sik_llms/openai.py
+++ b/src/sik_llms/openai.py
@@ -883,18 +883,20 @@ class OpenAITools(Client):
 
         if completion.choices[0].message.tool_calls:
             message = None
-            tool_call = completion.choices[0].message.tool_calls[0]
-            tool_prediction = ToolPrediction(
-                name=tool_call.function.name,
-                arguments=json.loads(tool_call.function.arguments),
-                call_id=tool_call.id,
-            )
+            tool_predictions = [
+                ToolPrediction(
+                    name=tc.function.name,
+                    arguments=json.loads(tc.function.arguments),
+                    call_id=tc.id,
+                )
+                for tc in completion.choices[0].message.tool_calls
+            ]
         else:
             message = completion.choices[0].message.content
-            tool_prediction = None
+            tool_predictions = []
 
         yield ToolPredictionResponse(
-            tool_prediction=tool_prediction,
+            tool_predictions=tool_predictions,
             message=message,
             input_tokens=input_tokens,
             output_tokens=output_tokens,

--- a/src/sik_llms/reasoning_agent.py
+++ b/src/sik_llms/reasoning_agent.py
@@ -377,10 +377,10 @@ class ReasoningAgent(Client):
                     total_cache_read_cost += tool_response.cache_read_cost or 0
                     total_cache_write_cost += tool_response.cache_write_cost or 0
 
-                    if tool_response.tool_prediction:
+                    if tool_response.tool_predictions:
                         # Use the tool name and arguments from the prediction
-                        predicted_tool_name = tool_response.tool_prediction.name
-                        predicted_tool_args = tool_response.tool_prediction.arguments
+                        predicted_tool_name = tool_response.tool_predictions[0].name
+                        predicted_tool_args = tool_response.tool_predictions[0].arguments
 
                         # Verify the predicted tool matches the requested tool
                         if predicted_tool_name != tool_name:

--- a/tests/test_anthropic.py
+++ b/tests/test_anthropic.py
@@ -678,7 +678,7 @@ class TestAnthropicCaching:
             user_message("What's the weather like in Tokyo in Celsius with forecast?"),
         ]
         response = client(messages=messages)
-        assert response.tool_prediction
+        assert response.tool_predictions
         assert response.input_tokens > 0
         assert response.output_tokens > 0
         assert response.cache_write_tokens > 0
@@ -706,7 +706,7 @@ class TestAnthropicCaching:
             user_message("Search for expensive italian restaurants in New York?"),
         ]
         response = client(messages=messages)
-        assert response.tool_prediction
+        assert response.tool_predictions
         assert response.input_tokens > 0
         assert response.output_tokens > 0
         assert response.cache_write_tokens == 0

--- a/tests/test_models_base.py
+++ b/tests/test_models_base.py
@@ -12,8 +12,6 @@ from sik_llms import (
     ImageContent,
     ImageSourceType,
     SUPPORTED_OPENAI_MODELS,
-    ToolPrediction,
-    ToolPredictionResponse,
 )
 from sik_llms.models_base import Parameter
 from tests.conftest import OPENAI_TEST_MODEL
@@ -442,51 +440,3 @@ class TestParameterClass:
         )
         assert param.param_type == list[str]
         assert param.required is False
-
-
-class TestToolPredictionResponse:
-    """Tests for ToolPredictionResponse backwards compatibility."""
-
-    def test_tool_prediction_property_with_single_prediction(self) -> None:
-        pred = ToolPrediction(name="get_weather", arguments={"city": "Paris"}, call_id="1")
-        response = ToolPredictionResponse(
-            tool_predictions=[pred],
-            input_tokens=10,
-            output_tokens=20,
-            duration_seconds=0.5,
-        )
-        assert response.tool_prediction is pred
-        assert response.tool_predictions == [pred]
-
-    def test_tool_prediction_property_with_multiple_predictions(self) -> None:
-        pred1 = ToolPrediction(name="get_weather", arguments={"city": "Paris"}, call_id="1")
-        pred2 = ToolPrediction(name="get_weather", arguments={"city": "London"}, call_id="2")
-        response = ToolPredictionResponse(
-            tool_predictions=[pred1, pred2],
-            input_tokens=10,
-            output_tokens=20,
-            duration_seconds=0.5,
-        )
-        assert response.tool_prediction is pred1
-        assert len(response.tool_predictions) == 2
-        assert response.tool_predictions[1] is pred2
-
-    def test_tool_prediction_property_with_no_predictions(self) -> None:
-        response = ToolPredictionResponse(
-            tool_predictions=[],
-            message="No tools needed.",
-            input_tokens=10,
-            output_tokens=20,
-            duration_seconds=0.5,
-        )
-        assert response.tool_prediction is None
-        assert response.message == "No tools needed."
-
-    def test_tool_prediction_default_empty_list(self) -> None:
-        response = ToolPredictionResponse(
-            input_tokens=10,
-            output_tokens=20,
-            duration_seconds=0.5,
-        )
-        assert response.tool_predictions == []
-        assert response.tool_prediction is None

--- a/tests/test_models_base.py
+++ b/tests/test_models_base.py
@@ -12,6 +12,8 @@ from sik_llms import (
     ImageContent,
     ImageSourceType,
     SUPPORTED_OPENAI_MODELS,
+    ToolPrediction,
+    ToolPredictionResponse,
 )
 from sik_llms.models_base import Parameter
 from tests.conftest import OPENAI_TEST_MODEL
@@ -430,7 +432,7 @@ class TestParameterClass:
         assert data['required'] is True
         assert data['description'] == "A test parameter"
 
-    def test_parameter_with_typing_generic(self):
+    def test_parameter_with_typing_generic(self) -> None:
         """Test Parameter with typing generics like list[str]."""
         param = Parameter(
             name="tags",
@@ -440,3 +442,51 @@ class TestParameterClass:
         )
         assert param.param_type == list[str]
         assert param.required is False
+
+
+class TestToolPredictionResponse:
+    """Tests for ToolPredictionResponse backwards compatibility."""
+
+    def test_tool_prediction_property_with_single_prediction(self) -> None:
+        pred = ToolPrediction(name="get_weather", arguments={"city": "Paris"}, call_id="1")
+        response = ToolPredictionResponse(
+            tool_predictions=[pred],
+            input_tokens=10,
+            output_tokens=20,
+            duration_seconds=0.5,
+        )
+        assert response.tool_prediction is pred
+        assert response.tool_predictions == [pred]
+
+    def test_tool_prediction_property_with_multiple_predictions(self) -> None:
+        pred1 = ToolPrediction(name="get_weather", arguments={"city": "Paris"}, call_id="1")
+        pred2 = ToolPrediction(name="get_weather", arguments={"city": "London"}, call_id="2")
+        response = ToolPredictionResponse(
+            tool_predictions=[pred1, pred2],
+            input_tokens=10,
+            output_tokens=20,
+            duration_seconds=0.5,
+        )
+        assert response.tool_prediction is pred1
+        assert len(response.tool_predictions) == 2
+        assert response.tool_predictions[1] is pred2
+
+    def test_tool_prediction_property_with_no_predictions(self) -> None:
+        response = ToolPredictionResponse(
+            tool_predictions=[],
+            message="No tools needed.",
+            input_tokens=10,
+            output_tokens=20,
+            duration_seconds=0.5,
+        )
+        assert response.tool_prediction is None
+        assert response.message == "No tools needed."
+
+    def test_tool_prediction_default_empty_list(self) -> None:
+        response = ToolPredictionResponse(
+            input_tokens=10,
+            output_tokens=20,
+            duration_seconds=0.5,
+        )
+        assert response.tool_predictions == []
+        assert response.tool_prediction is None

--- a/tests/test_openai.py
+++ b/tests/test_openai.py
@@ -770,7 +770,7 @@ class TestOpenAICaching:
             user_message("What's the weather like in Tokyo in Celsius with forecast?"),
         ]
         response = client(messages=messages)
-        assert response.tool_prediction
+        assert response.tool_predictions
         assert response.input_tokens > 0
         assert response.output_tokens > 0
         # first run should result in a cache-miss
@@ -796,7 +796,7 @@ class TestOpenAICaching:
             user_message("Search for expensive italian restaurants in New York?"),
         ]
         response = client(messages=messages)
-        assert response.tool_prediction
+        assert response.tool_predictions
         assert response.input_tokens > 0
         assert response.output_tokens > 0
         # now there should be a cache hit

--- a/tests/test_tool_calling.py
+++ b/tests/test_tool_calling.py
@@ -1397,7 +1397,6 @@ class TestTools:
         )
         assert isinstance(response, ToolPredictionResponse)
         assert len(response.tool_predictions) == 2
-        # tool_prediction should return the first one for backwards compatibility
         tool_names = {p.name for p in response.tool_predictions}
         assert tool_names == {"get_weather", "search_restaurants"}
         # each prediction should have a unique call_id

--- a/tests/test_tool_calling.py
+++ b/tests/test_tool_calling.py
@@ -1349,3 +1349,57 @@ class TestTools:
         # Check shipping_method
         assert "shipping_method" in args
         assert args["shipping_method"] == expected_method
+
+    @pytest.mark.parametrize('client_config', [
+        pytest.param(
+            ClientConfig(
+                client_type=RegisteredClients.OPENAI_TOOLS,
+                model_name=OPENAI_TEST_FUNCTION_CALLING,
+            ),
+            id="OpenAI",
+        ),
+        pytest.param(
+            ClientConfig(
+                client_type=RegisteredClients.ANTHROPIC_TOOLS,
+                model_name=ANTHROPIC_TEST_MODEL,
+            ),
+            id="Anthropic",
+            marks=pytest.mark.skipif(
+                os.getenv('ANTHROPIC_API_KEY') is None,
+                reason="ANTHROPIC_API_KEY is not set",
+            ),
+        ),
+    ])
+    async def test__parallel_tool_calls(
+            self,
+            simple_weather_tool: Tool,
+            restaurant_tool: Tool,
+            client_config: ClientConfig,
+        ) -> None:
+        """Test that parallel tool calls are returned in tool_predictions."""
+        client = Client.instantiate(
+            client_type=client_config.client_type,
+            model_name=client_config.model_name,
+            tools=[simple_weather_tool, restaurant_tool],
+            tool_choice=ToolChoice.AUTO,
+        )
+        response = await client.run_async(
+            messages=[
+                user_message(
+                    "This is a test of parallel tool calling. Please call BOTH of these "
+                    "tools in a single response: "
+                    "1) get_weather for Paris "
+                    "2) search_restaurants for Tokyo with cuisine=italian. "
+                    "You must call both tools at the same time.",
+                ),
+            ],
+        )
+        assert isinstance(response, ToolPredictionResponse)
+        assert len(response.tool_predictions) == 2
+        # tool_prediction should return the first one for backwards compatibility
+        assert response.tool_prediction is response.tool_predictions[0]
+        tool_names = {p.name for p in response.tool_predictions}
+        assert tool_names == {"get_weather", "search_restaurants"}
+        # each prediction should have a unique call_id
+        call_ids = {p.call_id for p in response.tool_predictions}
+        assert len(call_ids) == 2

--- a/tests/test_tool_calling.py
+++ b/tests/test_tool_calling.py
@@ -784,10 +784,11 @@ class TestTools:
                 ],
             )
         assert isinstance(response, ToolPredictionResponse)
-        assert isinstance(response.tool_prediction, ToolPrediction)
-        assert response.tool_prediction.name == "get_weather"
-        assert "location" in response.tool_prediction.arguments
-        assert "Paris" in response.tool_prediction.arguments["location"]
+        assert len(response.tool_predictions) == 1
+        assert isinstance(response.tool_predictions[0], ToolPrediction)
+        assert response.tool_predictions[0].name == "get_weather"
+        assert "location" in response.tool_predictions[0].arguments
+        assert "Paris" in response.tool_predictions[0].arguments["location"]
         assert response.input_tokens > 0
         assert response.output_tokens > 0
         assert response.input_cost > 0
@@ -831,7 +832,7 @@ class TestTools:
             ],
         )
         assert isinstance(response, ToolPredictionResponse)
-        assert response.tool_prediction is None
+        assert response.tool_predictions == []
         assert response.message
         assert response.input_tokens > 0
         assert response.output_tokens > 0
@@ -886,8 +887,8 @@ class TestTools:
                     user_message("What's the weather like in Tokyo in Celsius with forecast?"),
                 ],
             )
-        assert response.tool_prediction.name == "get_detailed_weather"
-        args = response.tool_prediction.arguments
+        assert response.tool_predictions[0].name == "get_detailed_weather"
+        args = response.tool_predictions[0].arguments
         assert "Tokyo" in args["location"]
         assert args.get("unit") in ["celsius", "fahrenheit"]
         assert args.get("include_forecast") is not None
@@ -942,8 +943,8 @@ class TestTools:
                     user_message("What's the weather like in London?"),
                 ],
             )
-        assert weather_response.tool_prediction.name == "get_weather"
-        assert "London" in weather_response.tool_prediction.arguments["location"]
+        assert weather_response.tool_predictions[0].name == "get_weather"
+        assert "London" in weather_response.tool_predictions[0].arguments["location"]
         # Restaurant query
         if is_async:
             restaurant_response = await client.run_async(
@@ -957,8 +958,8 @@ class TestTools:
                     user_message("Find me an expensive Italian restaurant in New York"),
                 ],
             )
-        assert restaurant_response.tool_prediction.name == "search_restaurants"
-        args = restaurant_response.tool_prediction.arguments
+        assert restaurant_response.tool_predictions[0].name == "search_restaurants"
+        args = restaurant_response.tool_predictions[0].arguments
         assert "New York" in args["location"]
         assert args.get("cuisine") == "italian"
         assert args.get("price_range") in ["$$", "$$$", "$$$$"]
@@ -1019,7 +1020,7 @@ class TestTools:
                 response = await client.run_async(messages=[user_message(prompt)])
             else:
                 response = client(messages=[user_message(prompt)])
-            args = response.tool_prediction.arguments
+            args = response.tool_predictions[0].arguments
             for key, value in expected_args.items():
                 assert args.get(key) == value
 
@@ -1062,8 +1063,8 @@ class TestTools:
         ))
 
         for i, response in enumerate(responses):
-            assert response.tool_prediction.name == "get_weather"
-            assert cities[i] in response.tool_prediction.arguments["location"]
+            assert response.tool_predictions[0].name == "get_weather"
+            assert cities[i] in response.tool_predictions[0].arguments["location"]
             assert response.input_tokens > 0
             assert response.output_tokens > 0
 
@@ -1129,8 +1130,8 @@ class TestTools:
         response = await client.run_async(
             messages=[user_message(prompt)],
         )
-        assert response.tool_prediction.name == "update_status"
-        args = response.tool_prediction.arguments
+        assert response.tool_predictions[0].name == "update_status"
+        args = response.tool_predictions[0].arguments
         assert "order_id" in args
         assert "status" in args
         assert args["status"] == expected_status
@@ -1211,8 +1212,8 @@ class TestTools:
         response = await client.run_async(
             messages=[user_message(prompt)],
         )
-        assert response.tool_prediction.name == "search_item"
-        args = response.tool_prediction.arguments
+        assert response.tool_predictions[0].name == "search_item"
+        args = response.tool_predictions[0].arguments
         assert "identifier" in args
 
         # Check that the identifier is of the expected type
@@ -1327,8 +1328,8 @@ class TestTools:
             messages=[user_message(prompt)],
         )
 
-        assert response.tool_prediction.name == "calculate_shipping"
-        args = response.tool_prediction.arguments
+        assert response.tool_predictions[0].name == "calculate_shipping"
+        args = response.tool_predictions[0].arguments
 
         # Check product_ids
         assert "product_ids" in args
@@ -1397,7 +1398,6 @@ class TestTools:
         assert isinstance(response, ToolPredictionResponse)
         assert len(response.tool_predictions) == 2
         # tool_prediction should return the first one for backwards compatibility
-        assert response.tool_prediction is response.tool_predictions[0]
         tool_names = {p.name for p in response.tool_predictions}
         assert tool_names == {"get_weather", "search_restaurants"}
         # each prediction should have a unique call_id

--- a/uv.lock
+++ b/uv.lock
@@ -1218,7 +1218,7 @@ wheels = [
 
 [[package]]
 name = "sik-llms"
-version = "0.3.28"
+version = "0.3.30"
 source = { editable = "." }
 dependencies = [
     { name = "anthropic" },


### PR DESCRIPTION
## Summary

`AnthropicTools.stream()` crashed with a `ValueError` when the API returned multiple tool_use blocks in a single response (parallel tool use). `OpenAITools.stream()` silently dropped all tool calls after the first. Both providers now correctly return all tool calls.

## Changes

- Replace `tool_prediction: ToolPrediction | None` with `tool_predictions: list[ToolPrediction]` on `ToolPredictionResponse`
- Fix `AnthropicTools.stream()` to iterate all content items instead of raising on `len(response.content) > 1`
- Fix `OpenAITools.stream()` to collect all tool calls instead of only the first
- Update all callers (`reasoning_agent.py`, `anthropic.py` structured output) to use `tool_predictions[0]`
- Add `claude-sonnet-4-6` model support and fix `claude-sonnet-4`/`claude-opus-4` aliases to `4-0`
- Add integration test for parallel tool calls against both providers
- Version bump: 0.3.29 → 0.3.30

## Impact

**Breaking change**: `ToolPredictionResponse.tool_prediction` (singular field) is removed. All consumers must migrate to `tool_predictions` (list). Access pattern changes from `response.tool_prediction.name` to `response.tool_predictions[0].name`, and truthiness checks change from `if response.tool_prediction` to `if response.tool_predictions`.